### PR TITLE
Add support for netstandard2.0

### DIFF
--- a/GoogleCast.SampleApp/GoogleCast.SampleApp.csproj
+++ b/GoogleCast.SampleApp/GoogleCast.SampleApp.csproj
@@ -51,11 +51,11 @@
     <Reference Include="GalaSoft.MvvmLight.Platform, Version=5.3.0.19032, Culture=neutral, PublicKeyToken=5f873c45e98af8a1, processorArchitecture=MSIL">
       <HintPath>..\packages\MvvmLightLibs.5.3.0.0\lib\net45\GalaSoft.MvvmLight.Platform.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=1.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.1.1.1\lib\netstandard1.1\Microsoft.Extensions.DependencyInjection.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.2.0.0\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=1.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.1.1\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.2.0.0\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Practices.ServiceLocation, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\CommonServiceLocator.1.3\lib\portable-net4+sl5+netcore45+wpa81+wp8\Microsoft.Practices.ServiceLocation.dll</HintPath>
@@ -63,8 +63,8 @@
     <Reference Include="Microsoft.Win32.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Win32.Primitives.4.3.0\lib\net46\Microsoft.Win32.Primitives.dll</HintPath>
     </Reference>
-    <Reference Include="protobuf-net, Version=2.2.1.0, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
-      <HintPath>..\packages\protobuf-net.2.2.1\lib\net40\protobuf-net.dll</HintPath>
+    <Reference Include="protobuf-net, Version=2.3.2.0, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
+      <HintPath>..\packages\protobuf-net.2.3.2\lib\net40\protobuf-net.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.AppContext, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -75,8 +75,8 @@
       <HintPath>..\packages\System.Console.4.3.0\lib\net46\System.Console.dll</HintPath>
     </Reference>
     <Reference Include="System.Data" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.3.1\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.4.1\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Globalization.Calendars, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Globalization.Calendars.4.3.0\lib\net46\System.Globalization.Calendars.dll</HintPath>
@@ -119,8 +119,8 @@
     <Reference Include="System.Reactive.Windows.Threading, Version=3.0.1000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Reactive.Windows.Threading.3.1.1\lib\net45\System.Reactive.Windows.Threading.dll</HintPath>
     </Reference>
-    <Reference Include="System.Reflection.TypeExtensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Reflection.TypeExtensions.4.3.0\lib\net46\System.Reflection.TypeExtensions.dll</HintPath>
+    <Reference Include="System.Reflection.TypeExtensions, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reflection.TypeExtensions.4.4.0\lib\net461\System.Reflection.TypeExtensions.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
@@ -162,8 +162,8 @@
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="Zeroconf, Version=2.8.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Zeroconf.2.8.0\lib\net45\Zeroconf.dll</HintPath>
+    <Reference Include="Zeroconf, Version=2.9.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Zeroconf.2.9.0\lib\net45\Zeroconf.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/GoogleCast.SampleApp/packages.config
+++ b/GoogleCast.SampleApp/packages.config
@@ -1,20 +1,20 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommonServiceLocator" version="1.3" targetFramework="net461" />
-  <package id="Microsoft.Extensions.DependencyInjection" version="1.1.1" targetFramework="net461" />
-  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.1.1" targetFramework="net461" />
-  <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net461" />
+  <package id="Microsoft.Extensions.DependencyInjection" version="2.0.0" targetFramework="net461" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.0.0" targetFramework="net461" />
+  <package id="Microsoft.NETCore.Platforms" version="2.0.0" targetFramework="net461" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net461" />
   <package id="MvvmLightLibs" version="5.3.0.0" targetFramework="net461" />
-  <package id="NETStandard.Library" version="1.6.1" targetFramework="net461" />
-  <package id="protobuf-net" version="2.2.1" targetFramework="net461" />
+  <package id="NETStandard.Library" version="2.0.0" targetFramework="net461" />
+  <package id="protobuf-net" version="2.3.2" targetFramework="net461" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net461" />
   <package id="System.Collections" version="4.3.0" targetFramework="net461" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net461" />
   <package id="System.ComponentModel" version="4.3.0" targetFramework="net461" />
   <package id="System.Console" version="4.3.0" targetFramework="net461" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net461" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.3.1" targetFramework="net461" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.1" targetFramework="net461" />
   <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net461" />
   <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net461" />
   <package id="System.Globalization" version="4.3.0" targetFramework="net461" />
@@ -40,7 +40,7 @@
   <package id="System.Reflection" version="4.3.0" targetFramework="net461" />
   <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net461" />
   <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net461" />
-  <package id="System.Reflection.TypeExtensions" version="4.3.0" targetFramework="net461" />
+  <package id="System.Reflection.TypeExtensions" version="4.4.0" targetFramework="net461" />
   <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net461" />
   <package id="System.Runtime" version="4.3.0" targetFramework="net461" />
   <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net461" />
@@ -62,5 +62,5 @@
   <package id="System.Threading.Timer" version="4.3.0" targetFramework="net461" />
   <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net461" />
   <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net461" />
-  <package id="Zeroconf" version="2.8.0" targetFramework="net461" />
+  <package id="Zeroconf" version="2.9.0" targetFramework="net461" />
 </packages>

--- a/GoogleCast/GoogleCast.csproj
+++ b/GoogleCast/GoogleCast.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <SignAssembly>False</SignAssembly>
     <AssemblyOriginatorKeyFile>key.pfx</AssemblyOriginatorKeyFile>
     <Authors>Stéphane Mitermite</Authors>
     <Company>Stéphane Mitermite</Company>
-    <Description>Implementation of the Google Cast protocol (.NET Standard 1.4 library).</Description>
+    <Description>Implementation of the Google Cast protocol (.NET Standard 2.0 library).</Description>
     <Copyright>Copyright © 2017 Stéphane Mitermite</Copyright>
     <PackageLicenseUrl>https://github.com/kakone/GoogleCast/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/kakone/GoogleCast</PackageProjectUrl>
@@ -30,14 +30,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.1.1" />
-    <PackageReference Include="protobuf-net" Version="2.2.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
+    <PackageReference Include="protobuf-net" Version="2.3.2" />
     <PackageReference Include="System.Net.Security" Version="4.3.1" />
     <PackageReference Include="System.Net.Sockets" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Json" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
-    <PackageReference Include="Zeroconf" Version="2.8.0" />
+    <PackageReference Include="Zeroconf" Version="2.9.0" />
   </ItemGroup>
 
 </Project>

--- a/GoogleCast/GoogleCast.csproj
+++ b/GoogleCast/GoogleCast.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard1.4;netstandard2.0</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <SignAssembly>False</SignAssembly>
     <AssemblyOriginatorKeyFile>key.pfx</AssemblyOriginatorKeyFile>
     <Authors>Stéphane Mitermite</Authors>
     <Company>Stéphane Mitermite</Company>
-    <Description>Implementation of the Google Cast protocol (.NET Standard 2.0 library).</Description>
+    <Description>Implementation of the Google Cast protocol (.NET Standard 1.4/2.0 library).</Description>
     <Copyright>Copyright © 2017 Stéphane Mitermite</Copyright>
     <PackageLicenseUrl>https://github.com/kakone/GoogleCast/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/kakone/GoogleCast</PackageProjectUrl>
@@ -20,7 +20,7 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <WarningLevel>4</WarningLevel>
-    <DocumentationFile>bin\Debug\netstandard1.4\GoogleCast.xml</DocumentationFile>
+    <DocumentationFile>bin\Debug\$(TargetFramework)\GoogleCast.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -30,14 +30,21 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
-    <PackageReference Include="protobuf-net" Version="2.3.2" />
+  <PackageReference Include="protobuf-net" Version="2.3.2" />
     <PackageReference Include="System.Net.Security" Version="4.3.1" />
     <PackageReference Include="System.Net.Sockets" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Json" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
     <PackageReference Include="Zeroconf" Version="2.9.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.4'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.1.1" />
   </ItemGroup>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # GoogleCast
-Implementation of the Google Cast protocol (.NET Standard 2.0 library).
+Implementation of the Google Cast protocol (.NET Standard 1.4/2.0 library).
 
 This [documentation](https://github.com/thibauts/node-castv2#protocol-description) was really helpful to understand the protocol.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # GoogleCast
-Implementation of the Google Cast protocol (.NET Standard 1.4 library).
+Implementation of the Google Cast protocol (.NET Standard 2.0 library).
 
 This [documentation](https://github.com/thibauts/node-castv2#protocol-description) was really helpful to understand the protocol.
 


### PR DESCRIPTION
Updated references to latest versions, added multi-targeting for netstandard1.4 and netstandard2.0. Because ASP.NET also uses Microsoft.Extensions.DependencyInjection, the new ASP.NET Core 2.0 targets the netstandard2.0 version of this library, which is incompatible with the 1.x version. Any .NET Core application targeting netcoreapp2.0 and Microsoft.Extensions.DependencyInjection 2.x will not work without this change.