### PR TITLE
Workaround for bug with Zeroconf and Chromecast Audio Groups

### DIFF
--- a/GoogleCast/DeviceLocator.cs
+++ b/GoogleCast/DeviceLocator.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using Zeroconf;
@@ -19,17 +18,17 @@ namespace GoogleCast
         /// <returns>a collection of receivers</returns>
         public async Task<IEnumerable<Receiver>> FindReceiversAsync()
         {
-			var receivers = new List<Receiver>();
-			await ZeroconfResolver.ResolveAsync(PROTOCOL, callback: c =>
-			{
-				var service = c.Services[PROTOCOL];
-				receivers.Add(new Receiver()
-				{
-					FriendlyName = service.Properties[0]["fn"],
-					IPEndPoint = new IPEndPoint(IPAddress.Parse(c.IPAddress), service.Port)
-				});
-			});
-			return receivers;
-		}
+            var receivers = new List<Receiver>();
+            await ZeroconfResolver.ResolveAsync(PROTOCOL, callback: c =>
+            {
+                var service = c.Services[PROTOCOL];
+                receivers.Add(new Receiver()
+                {
+                    FriendlyName = service.Properties[0]["fn"],
+                    IPEndPoint = new IPEndPoint(IPAddress.Parse(c.IPAddress), service.Port)
+                });
+            });
+            return receivers;
+        }
     }
 }

--- a/GoogleCast/DeviceLocator.cs
+++ b/GoogleCast/DeviceLocator.cs
@@ -19,15 +19,17 @@ namespace GoogleCast
         /// <returns>a collection of receivers</returns>
         public async Task<IEnumerable<Receiver>> FindReceiversAsync()
         {
-            return (await ZeroconfResolver.ResolveAsync(PROTOCOL)).Select(c =>
-            {
-                var service = c.Services[PROTOCOL];
-                return new Receiver()
-                {
-                    FriendlyName = service.Properties[0]["fn"],
-                    IPEndPoint = new IPEndPoint(IPAddress.Parse(c.IPAddress), service.Port)
-                };
-            });
-        }
+			var receivers = new List<Receiver>();
+			await ZeroconfResolver.ResolveAsync(PROTOCOL, callback: c =>
+			{
+				var service = c.Services[PROTOCOL];
+				receivers.Add(new Receiver()
+				{
+					FriendlyName = service.Properties[0]["fn"],
+					IPEndPoint = new IPEndPoint(IPAddress.Parse(c.IPAddress), service.Port)
+				});
+			});
+			return receivers;
+		}
     }
 }


### PR DESCRIPTION
There's a bug in Zeroconf making some Chromecasts un-discoverable if you use Chromecast Audio groups. Details in onovotny/Zeroconf#92. This fix just uses the async callback to process every discovery result as it is received instead of waiting for the entire batch to be returned from the async call. This avoids the bug where the only one of the multiple endpoints for the same IP Address are returned.