### PR TITLE
Add Set Volume Command

### DIFF
--- a/GoogleCast.SampleApp/MainViewModel.cs
+++ b/GoogleCast.SampleApp/MainViewModel.cs
@@ -212,14 +212,14 @@ namespace GoogleCast.SampleApp
             }
         }
 
-        private async Task SendChanneCommandAsync<TChannel>(bool condition, Func<TChannel, Task> action, Func<TChannel, Task> otherwise) where TChannel : IChannel
+        private async Task SendChannelCommandAsync<TChannel>(bool condition, Func<TChannel, Task> action, Func<TChannel, Task> otherwise) where TChannel : IChannel
         {
             await InvokeAsync<TChannel>(condition ? action : otherwise);
         }
 
         private async Task PlayAsync()
         {
-            await SendChanneCommandAsync<IMediaChannel>(!IsInitialized || IsStopped,
+            await SendChannelCommandAsync<IMediaChannel>(!IsInitialized || IsStopped,
                 async c =>
                 {
                     var selectedReceiver = SelectedReceiver;
@@ -238,12 +238,12 @@ namespace GoogleCast.SampleApp
 
         private async Task PauseAsync()
         {
-            await SendChanneCommandAsync<IMediaChannel>(IsStopped, null, async c => await c.PauseAsync());
+            await SendChannelCommandAsync<IMediaChannel>(IsStopped, null, async c => await c.PauseAsync());
         }
 
         private async Task StopAsync()
         {
-            await SendChanneCommandAsync<IMediaChannel>(IsStopped, null, async c => await c.StopAsync());
+            await SendChannelCommandAsync<IMediaChannel>(IsStopped, null, async c => await c.StopAsync());
         }
 
         private async Task RefreshAsync()
@@ -259,7 +259,7 @@ namespace GoogleCast.SampleApp
 
 		private async Task SetVolumeAsync()
 		{
-			await SendChanneCommandAsync<IReceiverChannel>(IsStopped, null, async c => await c.SetVolumeAsync(float.Parse(Volume), Muted));
+			await SendChannelCommandAsync<IReceiverChannel>(IsStopped, null, async c => await c.SetVolumeAsync(float.Parse(Volume), Muted));
 		}
 
         private void MediaChannelStatusChanged(object sender, EventArgs e)

--- a/GoogleCast.SampleApp/MainWindow.xaml
+++ b/GoogleCast.SampleApp/MainWindow.xaml
@@ -10,8 +10,9 @@
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
         </Grid.RowDefinitions>
         <Grid>
             <Grid.ColumnDefinitions>
@@ -33,6 +34,19 @@
             <Button Grid.Column="2" Margin="4" Padding="4" Width="64" Command="{Binding PauseCommand}">Pause</Button>
             <Button Grid.Column="3" Margin="4" Padding="4" Width="64" Command="{Binding StopCommand}">Stop</Button>
         </Grid>
-        <TextBlock Margin="4" Grid.Row="2" TextAlignment="Center" VerticalAlignment="Center" TextWrapping="Wrap" Text="{Binding PlayerState}" />
-    </Grid>
+		<Grid Grid.Row="2">
+			<Grid.ColumnDefinitions>
+				<ColumnDefinition Width="*" />
+				<ColumnDefinition Width="Auto" />
+				<ColumnDefinition Width="Auto" />
+				<ColumnDefinition Width="Auto" />
+				<ColumnDefinition Width="Auto" />
+			</Grid.ColumnDefinitions>
+			<TextBlock Margin="4" Grid.Column="0" TextAlignment="Center" VerticalAlignment="Center" TextWrapping="Wrap" Text="{Binding PlayerState}" />
+			<Label Grid.Column="1" VerticalContentAlignment="Center">Volume:</Label>
+			<TextBox Margin="4" Grid.Column="2" Text="{Binding Volume, Mode=TwoWay}" VerticalContentAlignment="Center"/>
+			<CheckBox Grid.Column="3" IsChecked="{Binding Muted, Mode=TwoWay}" VerticalContentAlignment="Center">Muted</CheckBox>
+			<Button Grid.Column="34" Margin="4" Padding="4" Width="64" Command="{Binding SetVolumeCommand}">Set</Button>
+		</Grid>
+	</Grid>
 </Window>

--- a/GoogleCast.SampleApp/MainWindow.xaml
+++ b/GoogleCast.SampleApp/MainWindow.xaml
@@ -10,9 +10,9 @@
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
-			<RowDefinition Height="Auto" />
-			<RowDefinition Height="Auto" />
-			<RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
         </Grid.RowDefinitions>
         <Grid>
             <Grid.ColumnDefinitions>
@@ -34,19 +34,18 @@
             <Button Grid.Column="2" Margin="4" Padding="4" Width="64" Command="{Binding PauseCommand}">Pause</Button>
             <Button Grid.Column="3" Margin="4" Padding="4" Width="64" Command="{Binding StopCommand}">Stop</Button>
         </Grid>
-		<Grid Grid.Row="2">
-			<Grid.ColumnDefinitions>
-				<ColumnDefinition Width="*" />
-				<ColumnDefinition Width="Auto" />
-				<ColumnDefinition Width="Auto" />
-				<ColumnDefinition Width="Auto" />
-				<ColumnDefinition Width="Auto" />
-			</Grid.ColumnDefinitions>
-			<TextBlock Margin="4" Grid.Column="0" TextAlignment="Center" VerticalAlignment="Center" TextWrapping="Wrap" Text="{Binding PlayerState}" />
-			<Label Grid.Column="1" VerticalContentAlignment="Center">Volume:</Label>
-			<TextBox Margin="4" Grid.Column="2" Text="{Binding Volume, Mode=TwoWay}" VerticalContentAlignment="Center"/>
-			<CheckBox Grid.Column="3" IsChecked="{Binding Muted, Mode=TwoWay}" VerticalContentAlignment="Center">Muted</CheckBox>
-			<Button Grid.Column="34" Margin="4" Padding="4" Width="64" Command="{Binding SetVolumeCommand}">Set</Button>
-		</Grid>
-	</Grid>
+        <Grid Grid.Row="2">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <Label VerticalAlignment="Center">Volume</Label>
+            <Slider Grid.Column="1"  Margin="4" Value="{Binding Volume, Mode=TwoWay}" Maximum="1" SmallChange="0.05" LargeChange="0.2" VerticalAlignment="Center"
+                    IsEnabled="{Binding AreButtonsEnabled}"/>
+            <CheckBox Grid.Column="2" Margin="4" IsChecked="{Binding IsMuted, Mode=TwoWay}" VerticalAlignment="Center"
+                      IsEnabled="{Binding AreButtonsEnabled}">Mute</CheckBox>
+        </Grid>
+        <TextBlock Grid.Row="3" TextAlignment="Center" VerticalAlignment="Center" TextWrapping="Wrap" Text="{Binding PlayerState}" />
+    </Grid>
 </Window>

--- a/GoogleCast.SampleApp/MainWindow.xaml.cs
+++ b/GoogleCast.SampleApp/MainWindow.xaml.cs
@@ -14,5 +14,5 @@ namespace GoogleCast.SampleApp
         {
             InitializeComponent();
         }
-	}
+    }
 }

--- a/GoogleCast.SampleApp/MainWindow.xaml.cs
+++ b/GoogleCast.SampleApp/MainWindow.xaml.cs
@@ -14,5 +14,5 @@ namespace GoogleCast.SampleApp
         {
             InitializeComponent();
         }
-    }
+	}
 }

--- a/GoogleCast/Channels/IReceiverChannel.cs
+++ b/GoogleCast/Channels/IReceiverChannel.cs
@@ -1,4 +1,5 @@
 ﻿using GoogleCast.Models.Receiver;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace GoogleCast.Channels
@@ -6,7 +7,7 @@ namespace GoogleCast.Channels
     /// <summary>
     /// Interface for the receiver channel
     /// </summary>
-    public interface IReceiverChannel : IChannel
+    public interface IReceiverChannel : IStatusChannel<ReceiverStatus>
     {
         /// <summary>
         /// Launches an application

--- a/GoogleCast/Channels/IReceiverChannel.cs
+++ b/GoogleCast/Channels/IReceiverChannel.cs
@@ -1,5 +1,4 @@
 ﻿using GoogleCast.Models.Receiver;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace GoogleCast.Channels
@@ -23,13 +22,18 @@ namespace GoogleCast.Channels
         /// <returns>an application object</returns>
         Task<Application> EnsureConnection(string ns);
 
+        /// <summary>
+        /// Sets the volume
+        /// </summary>
+        /// <param name="level">volume level (0.0 to 1.0)</param>
+        /// <returns>receiver status</returns>
+        Task<ReceiverStatus> SetVolumeAsync(float level);
 
-		/// <summary>
-		/// Sets the volume
-		/// </summary>
-		/// <param name="level">volume level (0.0 to 1.0)</param>
-		/// <param name="muted">muted state</param>
-		/// <returns>receiver status</returns>
-		Task<ReceiverStatus> SetVolumeAsync(float level, bool muted);
+        /// <summary>
+        /// Sets a value indicating whether the audio should be muted
+        /// </summary>
+        /// <param name="isMuted">true if audio should be muted; otherwise, false</param>
+        /// <returns>receiver status</returns>
+        Task<ReceiverStatus> SetIsMutedAsync(bool isMuted);
     }
 }

--- a/GoogleCast/Channels/IReceiverChannel.cs
+++ b/GoogleCast/Channels/IReceiverChannel.cs
@@ -21,5 +21,14 @@ namespace GoogleCast.Channels
         /// <param name="ns">namespace</param>
         /// <returns>an application object</returns>
         Task<Application> EnsureConnection(string ns);
+
+
+		/// <summary>
+		/// Sets the volume
+		/// </summary>
+		/// <param name="level">volume level (0.0 to 1.0)</param>
+		/// <param name="muted">muted state</param>
+		/// <returns>receiver status</returns>
+		Task<ReceiverStatus> SetVolumeAsync(float level, bool muted);
     }
 }

--- a/GoogleCast/Channels/ReceiverChannel.cs
+++ b/GoogleCast/Channels/ReceiverChannel.cs
@@ -49,7 +49,7 @@ namespace GoogleCast.Channels
         /// <returns>receiver status</returns>
         public async Task<ReceiverStatus> LaunchAsync(string applicationId)
         {
-            return (await SendAsync<ReceiverStatusMessage>(new LaunchMessage() { ApplicationId = applicationId })).Status;
+			return (await SendAsync<ReceiverStatusMessage>(new LaunchMessage() { ApplicationId = applicationId })).Status;
         }
 
 		/// <summary>
@@ -62,7 +62,7 @@ namespace GoogleCast.Channels
 		{
 			return (await SendAsync<ReceiverStatusMessage>(
 				new SetVolumeMessage() {
-					Volume = new Models.Volume() { Level = level, IsMuted = muted }
+					Volume = muted ? new Models.Volume() { IsMuted = true } : new Models.Volume() { Level = level, IsMuted = false }
 				}
 			)).Status;
 		}

--- a/GoogleCast/Channels/ReceiverChannel.cs
+++ b/GoogleCast/Channels/ReceiverChannel.cs
@@ -1,4 +1,5 @@
 ﻿using GoogleCast.Messages.Receiver;
+using GoogleCast.Models;
 using GoogleCast.Models.Receiver;
 using System.Linq;
 using System.Threading.Tasks;
@@ -49,30 +50,48 @@ namespace GoogleCast.Channels
         /// <returns>receiver status</returns>
         public async Task<ReceiverStatus> LaunchAsync(string applicationId)
         {
-			return (await SendAsync<ReceiverStatusMessage>(new LaunchMessage() { ApplicationId = applicationId })).Status;
+            return (await SendAsync<ReceiverStatusMessage>(new LaunchMessage() { ApplicationId = applicationId })).Status;
         }
 
-		/// <summary>
-		/// Sets the volume
-		/// </summary>
-		/// <param name="level">volume level (0.0 to 1.0)</param>
-		/// <param name="muted">muted state</param>
-		/// <returns>receiver status</returns>
-		public async Task<ReceiverStatus> SetVolumeAsync(float level, bool muted)
-		{
-			return (await SendAsync<ReceiverStatusMessage>(
-				new SetVolumeMessage() {
-					Volume = muted ? new Models.Volume() { IsMuted = true } : new Models.Volume() { Level = level, IsMuted = false }
-				}
-			)).Status;
-		}
+        /// <summary>
+        /// Sets the volume
+        /// </summary>
+        /// <param name="level">volume level (0.0 to 1.0)</param>
+        /// <returns>receiver status</returns>
+        public async Task<ReceiverStatus> SetVolumeAsync(float level)
+        {
+            return await SetVolumeAsync(level, null);
+        }
 
-		/// <summary>
-		/// Checks the connection is well established
-		/// </summary>
-		/// <param name="ns">namespace</param>
-		/// <returns>an application object</returns>
-		public async Task<Application> EnsureConnection(string ns)
+        /// <summary>
+        /// Sets a value indicating whether the audio should be muted
+        /// </summary>
+        /// <param name="isMuted">true if audio should be muted; otherwise, false</param>
+        /// <returns>receiver status</returns>
+        public async Task<ReceiverStatus> SetIsMutedAsync(bool isMuted)
+        {
+            return await SetVolumeAsync(null, isMuted);
+        }
+
+        private async Task<ReceiverStatus> SetVolumeAsync(float? level, bool? isMuted)
+        {
+            return (await SendAsync<ReceiverStatusMessage>(
+                new SetVolumeMessage()
+                {
+                    Volume = new Volume()
+                    {
+                        Level = level,
+                        IsMuted = isMuted,
+                    }
+                })).Status;
+        }
+
+        /// <summary>
+        /// Checks the connection is well established
+        /// </summary>
+        /// <param name="ns">namespace</param>
+        /// <returns>an application object</returns>
+        public async Task<Application> EnsureConnection(string ns)
         {
             if (Status == null)
             {

--- a/GoogleCast/Channels/ReceiverChannel.cs
+++ b/GoogleCast/Channels/ReceiverChannel.cs
@@ -52,12 +52,27 @@ namespace GoogleCast.Channels
             return (await SendAsync<ReceiverStatusMessage>(new LaunchMessage() { ApplicationId = applicationId })).Status;
         }
 
-        /// <summary>
-        /// Checks the connection is well established
-        /// </summary>
-        /// <param name="ns">namespace</param>
-        /// <returns>an application object</returns>
-        public async Task<Application> EnsureConnection(string ns)
+		/// <summary>
+		/// Sets the volume
+		/// </summary>
+		/// <param name="level">volume level (0.0 to 1.0)</param>
+		/// <param name="muted">muted state</param>
+		/// <returns>receiver status</returns>
+		public async Task<ReceiverStatus> SetVolumeAsync(float level, bool muted)
+		{
+			return (await SendAsync<ReceiverStatusMessage>(
+				new SetVolumeMessage() {
+					Volume = new Models.Volume() { Level = level, IsMuted = muted }
+				}
+			)).Status;
+		}
+
+		/// <summary>
+		/// Checks the connection is well established
+		/// </summary>
+		/// <param name="ns">namespace</param>
+		/// <returns>an application object</returns>
+		public async Task<Application> EnsureConnection(string ns)
         {
             if (Status == null)
             {

--- a/GoogleCast/Messages/Receiver/SetVolumeMessage.cs
+++ b/GoogleCast/Messages/Receiver/SetVolumeMessage.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace GoogleCast.Messages.Receiver
+{
+	/// <summary>
+	/// Set Volume Message
+	/// </summary>
+	[DataContract]
+	class SetVolumeMessage : MessageWithId
+	{
+		[DataMember(Name = "volume")]
+		public Models.Volume Volume { get; set; }
+    }
+}

--- a/GoogleCast/Messages/Receiver/SetVolumeMessage.cs
+++ b/GoogleCast/Messages/Receiver/SetVolumeMessage.cs
@@ -1,15 +1,18 @@
-﻿using System;
+﻿using GoogleCast.Models;
 using System.Runtime.Serialization;
 
 namespace GoogleCast.Messages.Receiver
 {
-	/// <summary>
-	/// Set Volume Message
-	/// </summary>
-	[DataContract]
-	class SetVolumeMessage : MessageWithId
-	{
-		[DataMember(Name = "volume")]
-		public Models.Volume Volume { get; set; }
+    /// <summary>
+    /// Volume Message
+    /// </summary>
+    [DataContract]
+    class SetVolumeMessage : MessageWithId
+    {
+        /// <summary>
+        /// Gets or sets the volume
+        /// </summary>
+        [DataMember(Name = "volume")]
+        public Volume Volume { get; set; }
     }
 }

--- a/GoogleCast/Models/Volume.cs
+++ b/GoogleCast/Models/Volume.cs
@@ -11,8 +11,8 @@ namespace GoogleCast.Models
         /// <summary>
         /// Gets or sets the volume level
         /// </summary>
-        [DataMember(Name = "level")]
-        public float Level { get; set; }
+        [DataMember(Name = "level", EmitDefaultValue = false)]
+        public float? Level { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether the audio is muted

--- a/GoogleCast/Models/Volume.cs
+++ b/GoogleCast/Models/Volume.cs
@@ -17,8 +17,8 @@ namespace GoogleCast.Models
         /// <summary>
         /// Gets or sets a value indicating whether the audio is muted
         /// </summary>
-        [DataMember(Name = "muted")]
-        public bool IsMuted { get; set; }
+        [DataMember(Name = "muted", EmitDefaultValue = false)]
+        public bool? IsMuted { get; set; }
 
         /// <summary>
         /// Gets or sets the step interval


### PR DESCRIPTION
Added StatusChanged event to IReceiverChannel to receive volume updates. Volume updates do not appear to be functional via IMediaChannel StatusChanged events.

In addition, there is a quirky (by design?) behavior I noticed while testing playing a video, where if you mute the volume, you must change the volume to be higher than the current volume in order to unmute the volume.

Also added volume controls to the Sample App for testing.