### PR TITLE
Add the ID to the receiver

### DIFF
--- a/GoogleCast/DeviceLocator.cs
+++ b/GoogleCast/DeviceLocator.cs
@@ -20,6 +20,7 @@ namespace GoogleCast
             var service = host.Services[PROTOCOL];
             return new Receiver()
             {
+                Id = service.Properties[0]["id"],
                 FriendlyName = service.Properties[0]["fn"],
                 IPEndPoint = new IPEndPoint(IPAddress.Parse(host.IPAddress), service.Port)
             };

--- a/GoogleCast/IReceiver.cs
+++ b/GoogleCast/IReceiver.cs
@@ -8,6 +8,10 @@ namespace GoogleCast
     public interface IReceiver
     {
         /// <summary>
+        /// Gets the Id
+        /// </summary>
+        string Id { get; }
+        /// <summary>
         /// Gets the friendly name
         /// </summary>
         string FriendlyName { get; }

--- a/GoogleCast/Receiver.cs
+++ b/GoogleCast/Receiver.cs
@@ -8,6 +8,10 @@ namespace GoogleCast
     public class Receiver : IReceiver
     {
         /// <summary>
+        /// Gets or sets the Id
+        /// </summary>
+        public string Id { get; set; }
+        /// <summary>
         /// Gets or sets the friendly name
         /// </summary>
         public string FriendlyName { get; set; }


### PR DESCRIPTION
Added the Id to the receiver - this is useful for keeping track of the device outside of attributes that can be changed by the user (FriendlyName and IP address).