### PR TITLE
Fix scanning from specific network interface/ip address

### DIFF
--- a/GoogleCast/DeviceLocator.cs
+++ b/GoogleCast/DeviceLocator.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Net.NetworkInformation;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
 using Zeroconf;
@@ -34,6 +35,15 @@ namespace GoogleCast
         public async Task<IEnumerable<IReceiver>> FindReceiversAsync()
         {
             return (await ZeroconfResolver.ResolveAsync(PROTOCOL)).Select(CreateReceiver);
+        }
+
+        /// <summary>
+        /// Finds the available receivers on specific network interface
+        /// </summary>
+        /// <returns>a collection of receivers</returns>
+        public async Task<IEnumerable<IReceiver>> FindReceiversAsync(NetworkInterface networkInterface)
+        {
+            return (await ZeroconfResolver.ResolveAsync(PROTOCOL, netInterfacesToSendRequestOn:new NetworkInterface[] { networkInterface })).Select(CreateReceiver);
         }
 
         /// <summary>

--- a/GoogleCast/GoogleCast.csproj
+++ b/GoogleCast/GoogleCast.csproj
@@ -33,7 +33,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
     <PackageReference Include="protobuf-net" Version="2.4.0" />
-    <PackageReference Include="Zeroconf" Version="3.0.30" />
+    <PackageReference Include="Zeroconf" Version="3.4.2" />
   </ItemGroup>
 
 </Project>

--- a/GoogleCast/IDeviceLocator.cs
+++ b/GoogleCast/IDeviceLocator.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Net.NetworkInformation;
 using System.Threading.Tasks;
 
 namespace GoogleCast
@@ -15,6 +16,12 @@ namespace GoogleCast
         /// <returns>a collection of receivers</returns>
         Task<IEnumerable<IReceiver>> FindReceiversAsync();
 
+        /// <summary>
+        /// Finds the available receivers on network interface
+        /// </summary>
+        /// <returns>a collection of receivers</returns>
+        Task<IEnumerable<IReceiver>> FindReceiversAsync(NetworkInterface networkInterface);
+        
         /// <summary>
         /// Finds the available receivers in continuous way
         /// </summary>


### PR DESCRIPTION
Closes #26 

I added a new method to the DeviceLocator interface to be able to scan on a specific network interface.  This fixes the fact that sometimes GoogleCast devices cannot be found.