### PR TITLE
Connect to Receiver using IP Address and Port.

### DIFF
--- a/GoogleCast.SampleApp/GoogleCast.SampleApp.csproj
+++ b/GoogleCast.SampleApp/GoogleCast.SampleApp.csproj
@@ -28,6 +28,6 @@
     <PackageReference Include="Microsoft.Toolkit.Mvvm" Version="7.0.1" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\GoogleCast\GoogleCast.csproj" />
+    <ProjectReference Include="..\GoogleCast\GoogleCastIP.csproj" />
   </ItemGroup>
 </Project>

--- a/GoogleCast.SampleApp/MainViewModel.cs
+++ b/GoogleCast.SampleApp/MainViewModel.cs
@@ -237,7 +237,8 @@ namespace GoogleCast.SampleApp
             var selectedReceiver = SelectedReceiver;
             if (selectedReceiver != null)
             {
-                await Sender.ConnectAsync(selectedReceiver);
+                //await Sender.ConnectAsync(selectedReceiver);
+                await Sender.ConnectAsync("192.168.3.142", 8009);
                 return true;
             }
             return false;

--- a/GoogleCast.sln
+++ b/GoogleCast.sln
@@ -1,9 +1,9 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31205.134
+# Visual Studio Version 17
+VisualStudioVersion = 17.4.33205.214
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GoogleCast", "GoogleCast\GoogleCast.csproj", "{0B336E66-C5C4-47B7-BD45-85847CCEF991}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GoogleCastIP", "GoogleCast\GoogleCastIP.csproj", "{0B336E66-C5C4-47B7-BD45-85847CCEF991}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GoogleCast.SampleApp", "GoogleCast.SampleApp\GoogleCast.SampleApp.csproj", "{347B2A0B-04B1-40D7-A63E-D0077A651306}"
 EndProject

--- a/GoogleCast/DeviceLocator.cs
+++ b/GoogleCast/DeviceLocator.cs
@@ -24,6 +24,7 @@ namespace GoogleCast
             {
                 Id = properties["id"],
                 FriendlyName = properties["fn"],
+                ModelName = properties["md"],
                 IPEndPoint = new IPEndPoint(IPAddress.Parse(host.IPAddress), service.Port)
             };
         }

--- a/GoogleCast/GoogleCastIP.csproj
+++ b/GoogleCast/GoogleCastIP.csproj
@@ -7,14 +7,14 @@
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <SignAssembly>False</SignAssembly>
     <AssemblyOriginatorKeyFile>key.pfx</AssemblyOriginatorKeyFile>
-    <Authors>Stéphane Mitermite</Authors>
-    <Company>Stéphane Mitermite</Company>
+    <Authors>Saqib Khan</Authors>
+    <Company>SmartAzan</Company>
     <Description>Implementation of the Google Cast protocol (.NET Standard 2.0 library).</Description>
     <Copyright>Copyright © 2021 Stéphane Mitermite</Copyright>
     <PackageProjectUrl>https://github.com/kakone/GoogleCast</PackageProjectUrl>
     <PackageTags>google cast googlecast chromecast</PackageTags>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>   
-    <Version>1.7.0</Version>
+    <Version>1.8</Version>
     <RepositoryUrl>https://github.com/kakone/GoogleCast</RepositoryUrl>
     <PackageLicenseExpression>AGPL-3.0-only</PackageLicenseExpression>
     <PackageIcon>GoogleCast.png</PackageIcon>
@@ -37,6 +37,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
+    <PackageReference Include="NuGet.CommandLine" Version="6.3.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="protobuf-net" Version="3.0.101" />
     <PackageReference Include="Zeroconf" Version="3.4.2" />
   </ItemGroup>

--- a/GoogleCast/GoogleCastIP.csproj
+++ b/GoogleCast/GoogleCastIP.csproj
@@ -14,7 +14,7 @@
     <PackageProjectUrl>https://github.com/kakone/GoogleCast</PackageProjectUrl>
     <PackageTags>google cast googlecast chromecast</PackageTags>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>   
-    <Version>1.8</Version>
+    <Version>1.9</Version>
     <RepositoryUrl>https://github.com/kakone/GoogleCast</RepositoryUrl>
     <PackageLicenseExpression>AGPL-3.0-only</PackageLicenseExpression>
     <PackageIcon>GoogleCast.png</PackageIcon>

--- a/GoogleCast/ISender.cs
+++ b/GoogleCast/ISender.cs
@@ -30,6 +30,19 @@ namespace GoogleCast
         /// <param name="receiver">receiver</param>
         Task ConnectAsync(IReceiver receiver);
 
+
+        /// <summary>
+        ///  Connects to a receiver using IP Address
+        /// </summary>
+        /// <param name="ipAddress"></param>
+        /// <param name="port"></param>
+        /// <returns></returns>
+        Task ConnectAsync(string ipAddress, int port);
+
+        /// <summary>
+        /// 
+
+
         /// <summary>
         /// Disconnects
         /// </summary>

--- a/GoogleCast/Receiver.cs
+++ b/GoogleCast/Receiver.cs
@@ -18,6 +18,11 @@ namespace GoogleCast
         public string FriendlyName { get; set; } = default!;
 
         /// <summary>
+        /// Gets or sets the Model name
+        /// </summary>
+        public string ModelName { get; set; } = default!;
+
+        /// <summary>
         /// Gets or sets the network endpoint
         /// </summary>
         public IPEndPoint IPEndPoint { get; set; } = default!;

--- a/GoogleCast/Sender.cs
+++ b/GoogleCast/Sender.cs
@@ -136,6 +136,25 @@ namespace GoogleCast
             await GetChannel<IConnectionChannel>().ConnectAsync();
         }
 
+        /// <inheritdoc/>
+        public async Task ConnectAsync(string ipAddress, int port)
+        {
+            Dispose();
+
+
+            var tcpClient = new TcpClient();
+            TcpClient = tcpClient;
+
+            var host = ipAddress;
+            await tcpClient.ConnectAsync(host, port);
+            var secureStream = new SslStream(tcpClient.GetStream(), true, (sender, certificate, chain, sslPolicyErrors) => true);
+            await secureStream.AuthenticateAsClientAsync(host);
+            NetworkStream = secureStream;
+
+            Receive();
+            await GetChannel<IConnectionChannel>().ConnectAsync();
+        }
+
         private void Receive()
         {
             var cancellationTokenSource = new CancellationTokenSource();

--- a/GoogleCast/Sender.cs
+++ b/GoogleCast/Sender.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Runtime.CompilerServices;


### PR DESCRIPTION
With many people using multiple wifi nodes, wifi mesh systems, GoogleCast cant Locate the Chromecasts on different subnet. I modified it so you can connect to Chromecast using IP Address.